### PR TITLE
Update dependencies, and support a quirky Bundler use-case.

### DIFF
--- a/fluent-plugin-dogstatsd.gemspec
+++ b/fluent-plugin-dogstatsd.gemspec
@@ -1,4 +1,6 @@
 # coding: utf-8
+require "fileutils"
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 

--- a/fluent-plugin-dogstatsd.gemspec
+++ b/fluent-plugin-dogstatsd.gemspec
@@ -11,7 +11,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ryotarai/fluent-plugin-dogstatsd"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  FileUtils.cd(File.expand_path('..', __FILE__)) do
+    spec.files       = `git ls-files -z`.split("\x0")
+  end
+
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]

--- a/fluent-plugin-dogstatsd.gemspec
+++ b/fluent-plugin-dogstatsd.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fluentd", [">= 0.14.0", "< 2"]
-  spec.add_dependency "dogstatsd-ruby", "~> 3.3.0"
+  spec.add_dependency "dogstatsd-ruby", "~> 5.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/fluent-plugin-dogstatsd.gemspec
+++ b/fluent-plugin-dogstatsd.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fluentd", [">= 0.14.0", "< 2"]
-  spec.add_dependency "dogstatsd-ruby", "~> 5.0"
+  spec.add_dependency "dogstatsd-ruby", [">= 3.3.0", "< 6"]
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
The dependency update is because, well, the (dogstatsd) gem has changed quite a bit along the way but still seems to be compatible.

The shenanigans in `Gemfile` are to support a fairly obscure behavior of Bundler:  The ability to override the source of a gem to use a local clone _without_ modifying `Gemfile` in the project that uses the gem.  Without this fix, RubyGems tries to use the list of files versioned in the project referencing the gem rather than in the local clone of the gem.  That leads to some very confusing warning messages.